### PR TITLE
Make README use Markdown rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,24 +1,25 @@
-The Pushfish Android Client [![License](http://img.shields.io/badge/license-BSD-blue.svg?style=flat)](/LICENSE)
-==========================
-This is the pushfish android client. It's using MQTT to communicate with the server. The client is licensed 
-under [BSD 2 clause][1] just like the rest of the project.
+# The Pushfish Android Client [![License](http://img.shields.io/badge/license-BSD-blue.svg?style=flat)](/LICENSE)
+
+This is the PushFish android client. It's using MQTT to communicate with the server. The client is licensed under [BSD 2 clause][1] just like the rest of the project.
 
 This is based on ![Pushjet](https://github.com/Pushjet/Pushjet-Android)
 
 ![Download latest apk](https://gitlab.com/PushFish/PushFish-Android/-/jobs/artifacts/master/raw/app/build/outputs/apk/app-debug.apk?job=build)
-## Permissions explained
-The [permissions][4] used by Pushfish might seem a bit broad but they all have a reason:
 
- - Read phone status and identity:
-  - This is needed [to generate the device uuid ][5] that authenticates the device with the server.
- - Take pictures and videos:
-  - This is needed to make sure we can scan QR codes to register new services.
- - Control flashlight/vibration and prevent phone from sleeping:
-  - This makes sure we can receive notifications.
+## Permissions explained
+
+The [permissions][4] used by PushFish might seem a bit broad but they all have a reason:
+
+- Read phone status and identity:
+- This is needed [to generate the device uuid][5] that authenticates the device with the server.
+- Take pictures and videos:
+- This is needed to make sure we can scan QR codes to register new services.
+- Control flashlight/vibration and prevent phone from sleeping:
+- This makes sure we can receive notifications.
 
 ## Screenshots
-![Pushfish push listing material][6] ![Pushfish push listing][2] ![Subscriptions][3]
 
+![Pushfish push listing material][6] ![Pushfish push listing][2] ![Subscriptions][3]
 
 [1]: https://tldrlegal.com/license/bsd-2-clause-license-%28freebsd%29
 [2]: http://pushjet.io/images/android/screenshot_1.png?1432482002


### PR DESCRIPTION
More information about the rules of Markdown: https://github.com/DavidAnson/markdownlint/blob/v0.11.0/doc/Rules.md
Fixed the capitalization of PushFish, as it's never capitalized the same way.